### PR TITLE
Update central.yaml

### DIFF
--- a/bootstrap/roles/ocp4-install-acs/tasks/central.yaml
+++ b/bootstrap/roles/ocp4-install-acs/tasks/central.yaml
@@ -16,7 +16,7 @@
     definition: "{{ lookup('template', 'subs.yml.j2') }}"
 
 - name: Wait for ACS CRD to exist
-  k8s_facts:
+  k8s_info:
     api_version: "apiextensions.k8s.io/v1beta1"
     kind: CustomResourceDefinition
     name: "{{ item }}"


### PR DESCRIPTION
kubernetes.core.k8s_facts was removed from kubernetes.core in version 2.0.0.  kubernetes.core.k8s_info has to be used instead.