### PR TITLE
Fix API references for OCP4.9 use

### DIFF
--- a/bootstrap/roles/ocp4-install-acs/tasks/central.yaml
+++ b/bootstrap/roles/ocp4-install-acs/tasks/central.yaml
@@ -17,7 +17,7 @@
 
 - name: Wait for ACS CRD to exist
   kubernetes.core.k8s_info:
-    api_version: "apiextensions.k8s.io/v1beta1"
+    api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "{{ item }}"
   loop: "{{ acs_expected_crds }}"

--- a/bootstrap/roles/ocp4-install-cicd/templates/cicd-gogs.yaml.j2
+++ b/bootstrap/roles/ocp4-install-cicd/templates/cicd-gogs.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: cicd
   annotations:
     image.openshift.io/triggers: >-
-        [{"from":{"kind":"ImageStreamTag","name":"postgresql:latest", "namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"postgresql\")].image"}]
+        [{"from":{"kind":"ImageStreamTag","name":"rhel8/postgresql-13:latest", "namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"postgresql\")].image"}]
   labels:
     app: gogs
     app.kubernetes.io/component: database
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: postgresql
         imagePullPolicy: Always
-        image: postgresql:latest
+        image: rhel8/postgresql-13:latest
         env:
         - name: POSTGRESQL_USER
           value: gogs

--- a/bootstrap/roles/ocp4-install-gitops/tasks/gitops.yaml
+++ b/bootstrap/roles/ocp4-install-gitops/tasks/gitops.yaml
@@ -5,7 +5,7 @@
 
 - name: Wait for GitOps CRD to exist
   kubernetes.core.k8s_info:
-    api_version: "apiextensions.k8s.io/v1beta1"
+    api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "{{ item }}"
   loop: "{{ gitops_expected_crds }}"
@@ -21,7 +21,7 @@
 
 - name: Wait for GitOps CRD to exist
   kubernetes.core.k8s_info:
-    api_version: "apiextensions.k8s.io/v1beta1"
+    api_version: "apiextensions.k8s.io/v1"
     kind: CustomResourceDefinition
     name: "{{ item }}"
   loop: "{{ pipelines_expected_crds }}"

--- a/bootstrap/roles/ocp4-install-gitops/templates/gitops-argocd.yaml.j2
+++ b/bootstrap/roles/ocp4-install-gitops/templates/gitops-argocd.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1
 kind: ArgoCD
 metadata:
   name: openshift-gitops

--- a/bootstrap/roles/ocp4-install-gitops/templates/subs-pipelines.yml.j2
+++ b/bootstrap/roles/ocp4-install-gitops/templates/subs-pipelines.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: openshift-pipelines-operator
+  name: openshift-pipelines-operator-rh
   namespace: openshift-operators
 spec:
   channel: stable


### PR DESCRIPTION
With OCP 4.9 the K8S version moved several API end points to v1 from v1beta1. 
Unfortunately these changes mean that the playbook will not work on prior versions - if that's important, some trickery querying the OCP version to determine which API to use is needed (will have to be another PR). 