### PR TITLE
added compatibility to 4.8 and 4.9. Fix issues with deprecations in 4.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 argocd/tmp-argocd-app-patch.yaml
+bootstrap/test.yaml

--- a/bootstrap/roles/ocp4-install-acs/tasks/central.yaml
+++ b/bootstrap/roles/ocp4-install-acs/tasks/central.yaml
@@ -1,3 +1,18 @@
+- name: Get cluster version
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: r_cluster_version
+
+- name: Set ocp4_cluster_version fact
+  set_fact:
+    ocp4_cluster_version: "{{ r_cluster_version.resources[0].status.history[0].version }}"
+
+- name: Print OpenShift version
+  debug:
+    msg: "{{ ocp4_cluster_version }}"
+
 - name: Create ACS namespace
   kubernetes.core.k8s:
     name: stackrox
@@ -15,16 +30,35 @@
     state: present
     definition: "{{ lookup('template', 'subs.yml.j2') }}"
 
-- name: Wait for ACS CRD to exist
-  kubernetes.core.k8s_info:
-    api_version: "apiextensions.k8s.io/v1beta1"
-    kind: CustomResourceDefinition
-    name: "{{ item }}"
-  loop: "{{ acs_expected_crds }}"
-  register: crds
-  until: crds.resources|length > 0
-  retries: 30
-  delay: 10
+- name: Adapt to the openshift_cluster_version LESS than 4.9
+  when: ocp4_cluster_version is version_compare('4.9', '<')
+  block:
+
+  - name: Wait for ACS CRD to exist
+    kubernetes.core.k8s_info:
+      api_version: "apiextensions.k8s.io/v1beta1"
+      kind: CustomResourceDefinition
+      name: "{{ item }}"
+    loop: "{{ acs_expected_crds }}"
+    register: crds
+    until: crds.resources|length > 0
+    retries: 30
+    delay: 10
+
+- name: Adapt to the openshift_cluster_version MORE than 4.9
+  when: ocp4_cluster_version is version_compare('4.9', '>=')
+  block:
+
+  - name: Wait for ACS CRD to exist
+    kubernetes.core.k8s_info:
+      api_version: "apiextensions.k8s.io/v1"
+      kind: CustomResourceDefinition
+      name: "{{ item }}"
+    loop: "{{ acs_expected_crds }}"
+    register: crds
+    until: crds.resources|length > 0
+    retries: 30
+    delay: 10
 
 - name: Wait for ACS Operator to be up and running
   pause:

--- a/bootstrap/roles/ocp4-install-cicd/templates/cicd-gogs.yaml.j2
+++ b/bootstrap/roles/ocp4-install-cicd/templates/cicd-gogs.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: cicd
   annotations:
     image.openshift.io/triggers: >-
-        [{"from":{"kind":"ImageStreamTag","name":"postgresql:latest", "namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"postgresql\")].image"}]
+        [{"from":{"kind":"ImageStreamTag","name":"rhel8/postgresql-13:latest", "namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"postgresql\")].image"}]
   labels:
     app: gogs
     app.kubernetes.io/component: database
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: postgresql
         imagePullPolicy: Always
-        image: postgresql:latest
+        image: rhel8/postgresql-13:latest
         env:
         - name: POSTGRESQL_USER
           value: gogs

--- a/bootstrap/roles/ocp4-install-gitops/tasks/gitops.yaml
+++ b/bootstrap/roles/ocp4-install-gitops/tasks/gitops.yaml
@@ -1,34 +1,87 @@
+- name: Get cluster version
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: r_cluster_version
+
+- name: Set ocp4_cluster_version fact
+  set_fact:
+    ocp4_cluster_version: "{{ r_cluster_version.resources[0].status.history[0].version }}"
+
+- name: Print OpenShift version
+  debug:
+    msg: "{{ ocp4_cluster_version }}"
+
 - name: Install GitOps Operator
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'subs-gitops.yml.j2') }}"
 
-- name: Wait for GitOps CRD to exist
-  kubernetes.core.k8s_info:
-    api_version: "apiextensions.k8s.io/v1beta1"
-    kind: CustomResourceDefinition
-    name: "{{ item }}"
-  loop: "{{ gitops_expected_crds }}"
-  register: crds
-  until: crds.resources|length > 0
-  retries: 30
-  delay: 10
+- name: Adapt to the openshift_cluster_version LESS than 4.9
+  when: ocp4_cluster_version is version_compare('4.9', '<')
+  block:
+
+  - name: Wait for GitOps CRD to exist
+    kubernetes.core.k8s_info:
+      api_version: "apiextensions.k8s.io/v1beta1"
+      kind: CustomResourceDefinition
+      name: "{{ item }}"
+    loop: "{{ gitops_expected_crds }}"
+    register: crds
+    until: crds.resources|length > 0
+    retries: 30
+    delay: 10
+
+- name: Adapt to the openshift_cluster_version MORE than 4.9
+  when: ocp4_cluster_version is version_compare('4.9', '>=')
+  block:
+
+  - name: Wait for GitOps CRD to exist
+    kubernetes.core.k8s_info:
+      api_version: "apiextensions.k8s.io/v1"
+      kind: CustomResourceDefinition
+      name: "{{ item }}"
+    loop: "{{ gitops_expected_crds }}"
+    register: crds
+    until: crds.resources|length > 0
+    retries: 30
+    delay: 10
 
 - name: Install OCP Pipelines Operator
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'subs-pipelines.yml.j2') }}"
 
-- name: Wait for GitOps CRD to exist
-  kubernetes.core.k8s_info:
-    api_version: "apiextensions.k8s.io/v1beta1"
-    kind: CustomResourceDefinition
-    name: "{{ item }}"
-  loop: "{{ pipelines_expected_crds }}"
-  register: crds
-  until: crds.resources|length > 0
-  retries: 30
-  delay: 10
+- name: Adapt to the openshift_cluster_version LESS than 4.9
+  when: ocp4_cluster_version is version_compare('4.9', '<')
+  block:
+
+  - name: Wait for Pipelines CRD to exist
+    kubernetes.core.k8s_info:
+      api_version: "apiextensions.k8s.io/v1beta1"
+      kind: CustomResourceDefinition
+      name: "{{ item }}"
+    loop: "{{ pipelines_expected_crds }}"
+    register: crds
+    until: crds.resources|length > 0
+    retries: 30
+    delay: 10
+
+- name: Adapt to the openshift_cluster_version MORE than 4.9
+  when: ocp4_cluster_version is version_compare('4.9', '>=')
+  block:
+
+  - name: Wait for Pipelines CRD to exist
+    kubernetes.core.k8s_info:
+      api_version: "apiextensions.k8s.io/v1"
+      kind: CustomResourceDefinition
+      name: "{{ item }}"
+    loop: "{{ pipelines_expected_crds }}"
+    register: crds
+    until: crds.resources|length > 0
+    retries: 30
+    delay: 10  
 
 - name: Add ClusterRoleBinding to the openshift-gitops-controller
   kubernetes.core.k8s:

--- a/bootstrap/roles/ocp4-install-gitops/templates/gitops-argocd.yaml.j2
+++ b/bootstrap/roles/ocp4-install-gitops/templates/gitops-argocd.yaml.j2
@@ -1,4 +1,8 @@
+{% if ocp4_cluster_version is version_compare('4.9', '<')%}
 apiVersion: argoproj.io/v1alpha1
+{% else %}
+apiVersion: argoproj.io/v1
+{% endif %}
 kind: ArgoCD
 metadata:
   name: openshift-gitops


### PR DESCRIPTION
Fixes of the 4.9 deprecations. Compatibility for 4.7/4.8.

Tested in 4.8.7 and 4.9.9 and both works properly.

```
$ bash install.sh
# INFO: Installing Demo

PLAY RECAP ********************************************************************************************************************
localhost                  : ok=72   changed=27   unreachable=0    failed=0    skipped=3    rescued=0    ignored=0
```