### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can check the `s2ijava-mgr.yaml` file for more details. We have added a step
 ```sh
 ansible-galaxy collection install community.kubernetes
 pip3 install kubernetes
+pip3 install openshift
 ```
 
 Install some extra Python dependency:


### PR DESCRIPTION
Without the 'pip3 install openshift', the ansible openshift modules do not work.